### PR TITLE
Add Windows installer build tooling and launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Installation
 
 Be aware, the [installation](https://docs.facefusion.io/installation) needs technical skills and is not recommended for beginners. In case you are not comfortable using a terminal, our [Windows Installer](https://windows-installer.facefusion.io) and [macOS Installer](https://macos-installer.facefusion.io) get you started.
 
+### Desktop installer
+
+Run `python desktop_installer.py` to launch a simple graphical helper that installs the required dependencies with a single click and offers to start FaceFusion once the setup is complete.
+
+To distribute the helper as a standalone Windows executable, install [PyInstaller](https://pyinstaller.org) and run `python build_facefusion_installer.py`. The resulting `FaceFusionInstaller.exe` is written to the `dist/` directory and contains everything needed to install the environment and immediately start FaceFusion.
+
 
 Usage
 -----

--- a/build_facefusion_installer.py
+++ b/build_facefusion_installer.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Build a standalone FaceFusion desktop installer executable."""
+
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+        try:
+                from PyInstaller.__main__ import run as pyinstaller_run
+        except ImportError as error:  # pragma: no cover - executed in packaging envs
+                sys.stderr.write('未安装 PyInstaller，请先运行 "pip install pyinstaller"。' + os.linesep)
+                raise SystemExit(1) from error
+
+        project_root = Path(__file__).resolve().parent
+        data_separator = ';' if os.name == 'nt' else ':'
+
+        add_data = [
+                f'{project_root / "requirements.txt"}{data_separator}.',
+                f'{project_root / "facefusion.py"}{data_separator}.',
+                f'{project_root / "facefusion.ini"}{data_separator}.',
+                f'{project_root / "facefusion"}{data_separator}facefusion'
+        ]
+
+        args = [
+                '--noconfirm',
+                '--clean',
+                '--onefile',
+                '--windowed',
+                f'--name=FaceFusionInstaller',
+                f'--icon={project_root / "facefusion.ico"}'
+        ]
+
+        for data in add_data:
+                args.extend(['--add-data', data])
+
+        args.append(str(project_root / 'desktop_installer.py'))
+
+        pyinstaller_run(args)
+
+
+if __name__ == '__main__':
+        main()

--- a/desktop_installer.py
+++ b/desktop_installer.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import threading
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Optional
+
+from facefusion import installer
+
+os.environ['SYSTEM_VERSION_COMPAT'] = '0'
+
+
+class DesktopInstaller:
+        def __init__(self, master : tk.Tk) -> None:
+                self.master = master
+                self.master.title('FaceFusion Environment Installer')
+                self.master.resizable(False, False)
+
+                self._set_window_icon()
+
+                container = ttk.Frame(self.master, padding = 16)
+                container.grid(row = 0, column = 0, sticky = 'nsew')
+
+                self.master.columnconfigure(0, weight = 1)
+                self.master.rowconfigure(0, weight = 1)
+
+                ttk.Label(container, text = '选择需要安装的 ONNX Runtime 版本：').grid(row = 0, column = 0, sticky = 'w')
+
+                self.runtime_var = tk.StringVar(value = self._default_runtime())
+                runtime_values = list(installer.ONNXRUNTIMES.keys())
+                self.runtime_combo = ttk.Combobox(container, textvariable = self.runtime_var, values = runtime_values, state = 'readonly', width = 18)
+                self.runtime_combo.grid(row = 1, column = 0, sticky = 'ew', pady = (4, 12))
+
+                self.skip_conda_var = tk.BooleanVar(value = False)
+                ttk.Checkbutton(container, text = '跳过 Conda 环境检测', variable = self.skip_conda_var).grid(row = 2, column = 0, sticky = 'w')
+
+                self.status_var = tk.StringVar(value = '点击“开始安装”以安装依赖环境。')
+                self.status_label = ttk.Label(container, textvariable = self.status_var, wraplength = 320)
+                self.status_label.grid(row = 3, column = 0, sticky = 'w', pady = (12, 8))
+
+                self.install_button = ttk.Button(container, text = '开始安装', command = self.start_install)
+                self.install_button.grid(row = 4, column = 0, sticky = 'ew')
+
+                self.launch_button = ttk.Button(container, text = '启动 FaceFusion', command = self.launch_facefusion)
+                self.launch_button.state(['disabled'])
+                self.launch_button.grid(row = 5, column = 0, sticky = 'ew', pady = (8, 0))
+
+                self.launch_process : Optional[subprocess.Popen[str]] = None
+
+        def _set_window_icon(self) -> None:
+                icon_path = installer.get_project_resource('facefusion.ico')
+                if os.path.exists(icon_path):
+                        try:
+                                self.master.iconbitmap(icon_path)  # type: ignore[attr-defined]
+                        except Exception:
+                                pass
+
+        def _default_runtime(self) -> str:
+                runtimes = list(installer.ONNXRUNTIMES.keys())
+                if 'default' in runtimes:
+                        return 'default'
+                if runtimes:
+                        return runtimes[0]
+                raise RuntimeError('No ONNX Runtime options available for this platform.')
+
+        def start_install(self) -> None:
+                onnxruntime_key = self.runtime_var.get()
+                skip_conda = self.skip_conda_var.get()
+
+                self.install_button.state(['disabled'])
+                self.launch_button.state(['disabled'])
+                self.status_var.set('正在安装依赖，请稍候……')
+
+                threading.Thread(target = self._run_installation, args = (onnxruntime_key, skip_conda), daemon = True).start()
+
+        def _run_installation(self, onnxruntime_key : str, skip_conda : bool) -> None:
+                try:
+                        installer.execute_install(onnxruntime_key, skip_conda)
+                except installer.InstallerError as error:
+                        self._report_failure(str(error) or '安装过程中出现错误。')
+                except SystemExit as error:
+                        message = '安装过程中出现错误。'
+                        if isinstance(error.code, str):
+                                message = error.code
+                        elif isinstance(error.code, int) and error.code != 0:
+                                message = '安装未完成 (退出代码 {code})。'.format(code = error.code)
+                        self._report_failure(message)
+                except Exception as error:
+                        self._report_failure(str(error) or '安装过程中出现未知错误。')
+                else:
+                        self._report_success()
+
+        def _report_success(self) -> None:
+                def callback() -> None:
+                        self.install_button.state(['!disabled'])
+                        self.launch_button.state(['!disabled'])
+                        self.status_var.set('安装完成，您可以立即启动 FaceFusion。')
+                        if messagebox.askyesno('安装完成', '依赖环境安装完成。是否现在启动 FaceFusion？'):
+                                self.launch_facefusion()
+                self.master.after(0, callback)
+
+        def _report_failure(self, message : str) -> None:
+                def callback() -> None:
+                        self.install_button.state(['!disabled'])
+                        self.launch_button.state(['disabled'])
+                        self.status_var.set(message)
+                        messagebox.showerror('安装失败', message)
+                self.master.after(0, callback)
+
+        def launch_facefusion(self) -> None:
+                if self.launch_process and self.launch_process.poll() is None:
+                        messagebox.showinfo('FaceFusion 已在运行', 'FaceFusion 已经启动，无需再次运行。')
+                        return
+
+                try:
+                        python_executable = installer.locate_python_interpreter()
+                except installer.InstallerError as error:
+                        messagebox.showerror('无法启动 FaceFusion', str(error))
+                        return
+
+                facefusion_entry = installer.get_project_resource('facefusion.py')
+                if not os.path.exists(facefusion_entry):
+                        messagebox.showerror('无法启动 FaceFusion', '未找到 facefusion.py 入口脚本。')
+                        return
+
+                command = [ python_executable, facefusion_entry, 'run' ]
+                try:
+                        self.launch_process = subprocess.Popen(command)
+                except OSError as error:
+                        messagebox.showerror('无法启动 FaceFusion', str(error))
+                else:
+                        messagebox.showinfo('FaceFusion 已启动', 'FaceFusion 正在启动，您可以最小化此窗口。')
+
+
+def main() -> None:
+        root = tk.Tk()
+        DesktopInstaller(root)
+        root.mainloop()
+
+
+if __name__ == '__main__':
+        main()

--- a/facefusion/installer.py
+++ b/facefusion/installer.py
@@ -5,90 +5,201 @@ import subprocess
 import sys
 import tempfile
 from argparse import ArgumentParser, HelpFormatter
-from typing import Dict, Tuple
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
 
 from facefusion import metadata, wording
 from facefusion.common_helper import is_linux, is_macos, is_windows
 
 ONNXRUNTIMES : Dict[str, Tuple[str, str]] = {}
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def get_project_resource(*parts : str) -> str:
+        """Return an absolute path to a project resource.
+
+        When the installer is packaged with PyInstaller the project files are
+        extracted to a temporary directory exposed via ``sys._MEIPASS``. In a
+        normal source checkout we simply resolve paths relative to the project
+        root.
+        """
+
+        base_path = getattr(sys, '_MEIPASS', PROJECT_ROOT)  # type: ignore[attr-defined]
+        return str(Path(base_path).joinpath(*parts))
+
+
+def run_pip(args : Iterable[str]) -> None:
+        """Execute ``pip`` with the provided arguments.
+
+        The helper attempts to reuse the in-process pip module when available so
+        that PyInstaller builds remain self-contained. When the module cannot be
+        imported we fall back to invoking the user's Python interpreter.
+        """
+
+        try:
+                from pip._internal.cli.main import main as pip_main  # type: ignore
+        except Exception as error:  # pragma: no cover - best effort fallback
+                python_candidates = []
+                if is_windows():
+                        python_candidates.extend(
+                        [
+                                os.path.join(os.getenv('CONDA_PREFIX', ''), 'python.exe'),
+                                shutil.which('pythonw'),
+                                shutil.which('python')
+                        ])
+                else:
+                        python_candidates.extend(
+                        [
+                                os.path.join(os.getenv('CONDA_PREFIX', ''), 'bin', 'python3'),
+                                shutil.which('python3'),
+                                shutil.which('python')
+                        ])
+                python_candidates.append(sys.executable)
+                python_executable = next(
+                        (candidate for candidate in python_candidates if candidate and os.path.exists(candidate)),
+                        None
+                )
+                if not python_executable:
+                        raise InstallerError('无法找到可用的 Python 或 pip 来安装依赖。') from error
+                exit_code = subprocess.call([ python_executable, '-m', 'pip', *list(args) ])
+        else:
+                exit_code = pip_main(list(args))
+
+        if exit_code != 0:
+                raise InstallerError('pip 执行失败 (退出代码 {code})。'.format(code = exit_code))
+
+
+def locate_python_interpreter() -> str:
+        """Return a Python interpreter path suitable for launching FaceFusion."""
+
+        candidates = []
+        if is_windows():
+                candidates.extend(
+                [
+                        os.path.join(os.getenv('CONDA_PREFIX', ''), 'python.exe'),
+                        shutil.which('pythonw'),
+                        shutil.which('python')
+                ])
+        else:
+                candidates.extend(
+                [
+                        os.path.join(os.getenv('CONDA_PREFIX', ''), 'bin', 'python3'),
+                        shutil.which('python3'),
+                        shutil.which('python')
+                ])
+        if not getattr(sys, 'frozen', False):  # pragma: no branch - simple check
+                candidates.append(sys.executable)
+
+        for candidate in candidates:
+                if candidate and os.path.exists(candidate):
+                        return str(candidate)
+
+        raise InstallerError('未能定位可用于启动 FaceFusion 的 Python 解释器。')
+
+# Importing ``pip`` as a top-level dependency ensures PyInstaller bundles it when
+# we package the desktop installer. The module is only referenced indirectly via
+# ``run_pip`` below.
+try:  # pragma: no cover - defensive import for packaging environments
+        import pip  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - pip may be unavailable during linting
+        pip = None
+
+
+class InstallerError(RuntimeError):
+        pass
+
+
 if is_macos():
-	ONNXRUNTIMES['default'] = ('onnxruntime', '1.19.2')
+        ONNXRUNTIMES['default'] = ('onnxruntime', '1.19.2')
 else:
-	ONNXRUNTIMES['default'] = ('onnxruntime', '1.19.2')
-	ONNXRUNTIMES['cuda'] = ('onnxruntime-gpu', '1.19.2')
-	ONNXRUNTIMES['openvino'] = ('onnxruntime-openvino', '1.19.0')
+        ONNXRUNTIMES['default'] = ('onnxruntime', '1.19.2')
+        ONNXRUNTIMES['cuda'] = ('onnxruntime-gpu', '1.19.2')
+        ONNXRUNTIMES['openvino'] = ('onnxruntime-openvino', '1.19.0')
 if is_linux():
-	ONNXRUNTIMES['rocm'] = ('onnxruntime-rocm', '1.18.0')
+        ONNXRUNTIMES['rocm'] = ('onnxruntime-rocm', '1.18.0')
 if is_windows():
-	ONNXRUNTIMES['directml'] = ('onnxruntime-directml', '1.17.3')
+        ONNXRUNTIMES['directml'] = ('onnxruntime-directml', '1.17.3')
 
 
 def cli() -> None:
-	signal.signal(signal.SIGINT, lambda signal_number, frame: sys.exit(0))
-	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 50))
-	program.add_argument('--onnxruntime', help = wording.get('help.install_dependency').format(dependency = 'onnxruntime'), choices = ONNXRUNTIMES.keys(), required = True)
-	program.add_argument('--skip-conda', help = wording.get('help.skip_conda'), action = 'store_true')
-	program.add_argument('-v', '--version', version = metadata.get('name') + ' ' + metadata.get('version'), action = 'version')
-	run(program)
+        signal.signal(signal.SIGINT, lambda signal_number, frame: sys.exit(0))
+        program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 50))
+        program.add_argument('--onnxruntime', help = wording.get('help.install_dependency').format(dependency = 'onnxruntime'), choices = ONNXRUNTIMES.keys(), required = True)
+        program.add_argument('--skip-conda', help = wording.get('help.skip_conda'), action = 'store_true')
+        program.add_argument('-v', '--version', version = metadata.get('name') + ' ' + metadata.get('version'), action = 'version')
+        run(program)
 
 
 def run(program : ArgumentParser) -> None:
-	args = program.parse_args()
-	has_conda = 'CONDA_PREFIX' in os.environ
-	onnxruntime_name, onnxruntime_version = ONNXRUNTIMES.get(args.onnxruntime)
+        args = program.parse_args()
+        try:
+                execute_install(args.onnxruntime, args.skip_conda)
+        except InstallerError as error:
+                message = str(error)
+                if message:
+                        sys.stdout.write(message + os.linesep)
+                sys.exit(1)
 
-	if not args.skip_conda and not has_conda:
-		sys.stdout.write(wording.get('conda_not_activated') + os.linesep)
-		sys.exit(1)
 
-	subprocess.call([ shutil.which('pip'), 'install', '-r', 'requirements.txt', '--force-reinstall' ])
+def execute_install(onnxruntime_key : str, skip_conda : bool = False) -> None:
+        if onnxruntime_key not in ONNXRUNTIMES:
+                raise InstallerError('Unknown ONNX Runtime selection: ' + onnxruntime_key)
 
-	if args.onnxruntime == 'rocm':
-		python_id = 'cp' + str(sys.version_info.major) + str(sys.version_info.minor)
+        has_conda = 'CONDA_PREFIX' in os.environ
+        onnxruntime_name, onnxruntime_version = ONNXRUNTIMES.get(onnxruntime_key)
+        requirements_path = get_project_resource('requirements.txt')
 
-		if python_id == 'cp310':
-			wheel_name = 'onnxruntime_rocm-' + onnxruntime_version +'-' + python_id + '-' + python_id + '-linux_x86_64.whl'
-			wheel_path = os.path.join(tempfile.gettempdir(), wheel_name)
-			wheel_url = 'https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2/' + wheel_name
-			subprocess.call([ shutil.which('curl'), '--silent', '--location', '--continue-at', '-', '--output', wheel_path, wheel_url ])
-			subprocess.call([ shutil.which('pip'), 'uninstall', 'onnxruntime', wheel_path, '-y', '-q' ])
-			subprocess.call([ shutil.which('pip'), 'install', wheel_path, '--force-reinstall' ])
-			os.remove(wheel_path)
-	else:
-		subprocess.call([ shutil.which('pip'), 'uninstall', 'onnxruntime', onnxruntime_name, '-y', '-q' ])
-		subprocess.call([ shutil.which('pip'), 'install', onnxruntime_name + '==' + onnxruntime_version, '--force-reinstall' ])
+        if not skip_conda and not has_conda:
+                raise InstallerError(wording.get('conda_not_activated') or 'Conda is not activated')
 
-	if args.onnxruntime == 'cuda' and has_conda:
-		library_paths = []
+        run_pip([ 'install', '-r', requirements_path, '--force-reinstall' ])
 
-		if is_linux():
-			if os.getenv('LD_LIBRARY_PATH'):
-				library_paths = os.getenv('LD_LIBRARY_PATH').split(os.pathsep)
+        if onnxruntime_key == 'rocm':
+                python_id = 'cp' + str(sys.version_info.major) + str(sys.version_info.minor)
 
-			python_id = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
-			library_paths.extend(
-			[
-				os.path.join(os.getenv('CONDA_PREFIX'), 'lib'),
-				os.path.join(os.getenv('CONDA_PREFIX'), 'lib', python_id, 'site-packages', 'tensorrt_libs')
-			])
-			library_paths = [ library_path for library_path in library_paths if os.path.exists(library_path) ]
+                if python_id == 'cp310':
+                        wheel_name = 'onnxruntime_rocm-' + onnxruntime_version + '-' + python_id + '-' + python_id + '-linux_x86_64.whl'
+                        wheel_path = os.path.join(tempfile.gettempdir(), wheel_name)
+                        wheel_url = 'https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2/' + wheel_name
+                        subprocess.call([ shutil.which('curl'), '--silent', '--location', '--continue-at', '-', '--output', wheel_path, wheel_url ])
+                        run_pip([ 'uninstall', 'onnxruntime', wheel_path, '-y', '-q' ])
+                        run_pip([ 'install', wheel_path, '--force-reinstall' ])
+                        os.remove(wheel_path)
+        else:
+                run_pip([ 'uninstall', 'onnxruntime', onnxruntime_name, '-y', '-q' ])
+                run_pip([ 'install', onnxruntime_name + '==' + onnxruntime_version, '--force-reinstall' ])
 
-			subprocess.call([ shutil.which('conda'), 'env', 'config', 'vars', 'set', 'LD_LIBRARY_PATH=' + os.pathsep.join(library_paths) ])
+        if onnxruntime_key == 'cuda' and has_conda:
+                library_paths = []
 
-		if is_windows():
-			if os.getenv('PATH'):
-				library_paths = os.getenv('PATH').split(os.pathsep)
+                if is_linux():
+                        if os.getenv('LD_LIBRARY_PATH'):
+                                library_paths = os.getenv('LD_LIBRARY_PATH').split(os.pathsep)
 
-			library_paths.extend(
-			[
-				os.path.join(os.getenv('CONDA_PREFIX'), 'Lib'),
-				os.path.join(os.getenv('CONDA_PREFIX'), 'Lib', 'site-packages', 'tensorrt_libs')
-			])
-			library_paths = [ library_path for library_path in library_paths if os.path.exists(library_path) ]
+                        python_id = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+                        library_paths.extend(
+                        [
+                                os.path.join(os.getenv('CONDA_PREFIX'), 'lib'),
+                                os.path.join(os.getenv('CONDA_PREFIX'), 'lib', python_id, 'site-packages', 'tensorrt_libs')
+                        ])
+                        library_paths = [ library_path for library_path in library_paths if os.path.exists(library_path) ]
 
-			subprocess.call([ shutil.which('conda'), 'env', 'config', 'vars', 'set', 'PATH=' + os.pathsep.join(library_paths) ])
+                        subprocess.call([ shutil.which('conda'), 'env', 'config', 'vars', 'set', 'LD_LIBRARY_PATH=' + os.pathsep.join(library_paths) ])
 
-	if onnxruntime_version < '1.19.0':
-		subprocess.call([ shutil.which('pip'), 'install', 'numpy==1.26.4', '--force-reinstall' ])
-	subprocess.call([ shutil.which('pip'), 'install', 'python-multipart==0.0.12', '--force-reinstall' ])
+                if is_windows():
+                        if os.getenv('PATH'):
+                                library_paths = os.getenv('PATH').split(os.pathsep)
+
+                        library_paths.extend(
+                        [
+                                os.path.join(os.getenv('CONDA_PREFIX'), 'Lib'),
+                                os.path.join(os.getenv('CONDA_PREFIX'), 'Lib', 'site-packages', 'tensorrt_libs')
+                        ])
+                        library_paths = [ library_path for library_path in library_paths if os.path.exists(library_path) ]
+
+                        subprocess.call([ shutil.which('conda'), 'env', 'config', 'vars', 'set', 'PATH=' + os.pathsep.join(library_paths) ])
+
+        if onnxruntime_version < '1.19.0':
+                run_pip([ 'install', 'numpy==1.26.4', '--force-reinstall' ])
+        run_pip([ 'install', 'python-multipart==0.0.12', '--force-reinstall' ])


### PR DESCRIPTION
## Summary
- enhance the desktop installer so it can launch FaceFusion after dependencies are installed and show status updates
- update the Python installer backend with PyInstaller-aware resource helpers and pip execution utilities
- add a PyInstaller build script and documentation for creating a standalone FaceFusionInstaller.exe

## Testing
- python -m compileall desktop_installer.py facefusion/installer.py build_facefusion_installer.py

------
https://chatgpt.com/codex/tasks/task_e_68dfcc328ec8832886996d342d8b486d